### PR TITLE
Update polya_fit_simple.cpp

### DIFF
--- a/src/polya_fit_simple.cpp
+++ b/src/polya_fit_simple.cpp
@@ -26,6 +26,7 @@ USA
 
 ***********************************************************************/
 
+#include <stdio.h>
 #include "polya_fit_simple.h"
 #include "math_func.h"
 #include <math.h>


### PR DESCRIPTION
This change is needed for make to compile successfully on gcc 4.9.2 (tested on Debian Linux).  Without the change, the following error is encountered:
`../src/polya_fit_simple.cpp:71:37: error: ‘printf’ was not declared in this scope
  printf("Optimising parameters...\n");
                                     ^
src/subdir.mk:39: recipe for target 'src/polya_fit_simple.o' failed`

With the change, make compiles jst without issue.
